### PR TITLE
[DO NOT MERGE] Demonstrates using an adapter to avoid having to refactor everything at once

### DIFF
--- a/Exercise/Exercise/Config/ConfigProviderJson.cs
+++ b/Exercise/Exercise/Config/ConfigProviderJson.cs
@@ -1,0 +1,80 @@
+﻿using Exercise.Rules;
+using Newtonsoft.Json;
+
+namespace Exercise
+{
+    internal class ConfigProviderJson : IConfigProvider
+    {
+        private ConfigurationJson configuration;
+
+        public ConfigProviderJson(string filePath, List<IRule> availableRules)
+        {
+            var userConfiguration = CreateUserConfiguration(filePath);
+            InitializeConfig(userConfiguration, availableRules);
+        }
+
+        private UserConfiguration CreateUserConfiguration(string filePath)
+        {
+            var configFileContent = System.IO.File.ReadAllText(filePath);
+            var userConfiguration = JsonConvert.DeserializeObject<UserConfiguration>(configFileContent);
+
+            if (userConfiguration == null)
+            {
+                throw new Exception("Rule Configuration could not be Deserialized");
+            }
+
+            return userConfiguration;
+        }
+
+        private void InitializeConfig(UserConfiguration userConfiguration, List<IRule> availableRules)
+        {
+            var ruleConfigs = new List<IRuleConfig>();
+            var rulesToExecute = availableRules.Where(rule => userConfiguration.rules.ContainsKey(rule.RuleId)).ToList();
+
+            foreach (var rule in rulesToExecute)
+            {
+                var ruleConfigJson = rule.HasParameters
+                                     ? new RuleConfigJson(rule.RuleId, userConfiguration.rules[rule.RuleId][0])
+                                     : new RuleConfigJson(rule.RuleId);
+                ruleConfigs.Add(ruleConfigJson);
+            }
+
+            configuration = new ConfigurationJson(userConfiguration.fileToAnalyze, ruleConfigs);
+        }
+
+        public IConfiguration GetConfiguration()
+        {
+            return configuration;
+        }
+    }
+
+    public class ConfigurationJson : IConfiguration
+    {
+        public ConfigurationJson(string fileToAnalyze, IEnumerable<IRuleConfig> rules)
+        {
+            this.FileToAnalyze = fileToAnalyze;
+            this.Rules = rules;
+        }
+
+        public string FileToAnalyze { get; }
+
+        public IEnumerable<IRuleConfig> Rules { get; }
+    }
+
+    public class RuleConfigJson : IRuleConfig
+    {
+        public RuleConfigJson(string ruleId)
+        {
+            this.RuleId = ruleId;
+        }
+
+        public RuleConfigJson(string ruleId, int param)
+        {
+            this.RuleId = ruleId;
+            this.RuleParam = param;
+        }
+
+        public string RuleId { get; }
+        public int RuleParam { get; }
+    }
+}

--- a/Exercise/Exercise/Config/ConfigProviderUser.cs
+++ b/Exercise/Exercise/Config/ConfigProviderUser.cs
@@ -1,0 +1,131 @@
+﻿using Exercise.Rules;
+
+namespace Exercise
+{
+    internal class ConfigProviderUser : IConfigProvider
+    {
+        private IConfiguration configuration;
+
+        public ConfigProviderUser(IEnumerable<IRule> rules)
+        {
+            InitializeConfig(rules);
+        }
+        public IConfiguration GetConfiguration()
+        {
+            return configuration;
+        }
+
+        private void InitializeConfig(IEnumerable<IRule> availableRules)
+        {
+            var fileToAnalyze = ReadUserInputForFilePath(".txt");
+            var ruleConfigs = CreateRuleConfigsWithUserInput(availableRules);
+
+            configuration = new ConfigurationUser(fileToAnalyze, ruleConfigs);
+        }
+
+
+        private IEnumerable<IRuleConfig> CreateRuleConfigsWithUserInput(IEnumerable<IRule> availableRules)
+        {
+            var ruleConfigs = new List<IRuleConfig>();
+            Console.WriteLine("Enter ctrl c to exit input.");
+
+            foreach (var rule in availableRules)
+            {
+                Console.WriteLine("Add rule: " + rule.RuleId + " to analyzer? y for yes, any other key for no");
+
+                var input = Console.ReadLine();
+
+                if (input == null)
+                {
+                    break;
+                }
+
+                if (input != "y") continue;
+
+                RuleConfigUser ruleConfig;
+
+                if (rule.HasParameters)
+                {
+                    var ruleParam = GetInputParams("Input rule param");
+                    ruleConfig = new RuleConfigUser(rule.RuleId, ruleParam);
+                }
+                else
+                {
+                    ruleConfig = new RuleConfigUser(rule.RuleId);
+                }
+
+                ruleConfigs.Add(ruleConfig);
+            }
+
+            return ruleConfigs;
+        }
+
+        private static int GetInputParams(string displayText)
+        {
+            Console.WriteLine(displayText);
+            string? input;
+            int number;
+
+            do
+            {
+                input = Console.ReadLine();
+            } while (!int.TryParse(input, out number));
+
+            return number;
+        }
+
+        private static string ReadUserInputForFilePath(string fileExtension)
+        {
+            Console.WriteLine("Please input path for file to be analyzed");
+            var inputValidator = new InputValidator();
+            var filePath = "";
+
+            do
+            {
+                var input = Console.ReadLine();
+
+                if (input == null)
+                {
+                    Console.WriteLine("Exiting Analyzer");
+
+                    break;
+                }
+
+                filePath = input;
+            } while (!(inputValidator.FileHasCorrectExtension(filePath, fileExtension) &&
+                       inputValidator.FileExists(filePath)));
+
+            return filePath;
+        }
+    }
+
+    public class ConfigurationUser : IConfiguration
+    {
+        public ConfigurationUser(string fileToAnalyze, IEnumerable<IRuleConfig> rules)
+        {
+            this.FileToAnalyze = fileToAnalyze;
+            this.Rules = rules;
+        }
+
+        public string FileToAnalyze { get; }
+
+        public IEnumerable<IRuleConfig> Rules { get; }
+    }
+
+    public class RuleConfigUser : IRuleConfig
+    {
+        public RuleConfigUser(string ruleId)
+        {
+            this.RuleId = ruleId;
+        }
+
+        public RuleConfigUser(string ruleId, int param)
+        {
+            this.RuleId = ruleId;
+            this.RuleParam = param;
+        }
+
+        public string RuleId { get; }
+        public int RuleParam { get; }
+    }
+}

--- a/Exercise/Exercise/Config/IConfigProvider.cs
+++ b/Exercise/Exercise/Config/IConfigProvider.cs
@@ -1,0 +1,21 @@
+﻿namespace Exercise
+{
+    public partial interface IConfiguration
+    {
+        string FileToAnalyze { get; }
+
+        IEnumerable<IRuleConfig> Rules { get; }
+    }
+
+    public interface IRuleConfig
+    {
+        string RuleId { get; }
+
+        int RuleParam { get; }
+    }
+
+    public interface IConfigProvider
+    {
+        IConfiguration GetConfiguration();
+    }
+}

--- a/Exercise/Exercise/IRuleParameterConfig.cs
+++ b/Exercise/Exercise/IRuleParameterConfig.cs
@@ -4,4 +4,25 @@
     {
         int GetRuleParam(string key);
     }
+
+    // HACK - to avoid breaking all of the rules and tests, we could add
+    // an adapter class that translates between the new IConfiguration class
+    // and the old IRuleParameterConfig class.
+    //
+    // That way we don't have to refactor everything at once; we can do it in
+    // a number of smaller PRs, rather than in one big bang.
+    public class ConfigToRuleParameterConfigAdapter : IRuleParameterConfig
+    {
+        private readonly IConfiguration configuration;
+
+        public ConfigToRuleParameterConfigAdapter(IConfiguration configuration)
+        {
+            this.configuration = configuration;
+        }
+
+        public int GetRuleParam(string key)
+        {
+            return configuration.Rules.FirstOrDefault(x => x.RuleId == key)?.RuleParam ?? 0;
+        }
+    }
 }


### PR DESCRIPTION
There are two commits:
* the first adds the new `IConfigurationProvider` interfaces and implementations that you created, but doesn't change any of the existing code.
* the second changes `Program` class to use the new classes.

To avoid breaking the existing analyzer and rules, I've introduced an adapter class that translates between the old and new configuration formats.

This approach means we can make smaller changes and still keep the code and tests running. It also makes life easier for code reviewers, since we can create smaller PRs. 